### PR TITLE
fix handling zero frames case

### DIFF
--- a/soxr.c
+++ b/soxr.c
@@ -173,6 +173,10 @@ ddb_soxr_can_bypass (ddb_dsp_context_t *_opt, ddb_waveformat_t *fmt) {
 
 int
 ddb_soxr_process (ddb_dsp_context_t *_opt, float *samples, int nframes, int maxframes, ddb_waveformat_t *fmt, float *r) {
+    if (!nframes) {
+        *r = 1;
+        return nframes;
+    }
     ddb_soxr_opt_t *opt = (ddb_soxr_opt_t*)_opt;
 
     if (opt->autosamplerate) {


### PR DESCRIPTION
Deadbeef can sometimes call dsp plugins with 0 frames to process, in order to calculate ratio before doing any processing. This is in some way a backwards compatibility issue, which I might be able to fix in the future, but right now that the only way to make this plugin work with deadbeef master.